### PR TITLE
Add sections to lerna-changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fix": "yarn lint -- --fix",
     "lint": "eslint src --ext ts --format stylish",
     "prepublish": "yarn build",
+    "prepare": "yarn build",
     "prettier": "prettier --write 'src/**/*.ts'",
     "test": "jest",
     "test-ci": "yarn build && yarn test",

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -31,12 +31,6 @@ export default class Changelog {
       baseIssueUrl: this.github.getBaseIssueUrl(this.config.repo),
       unreleasedName: this.config.nextVersion || "Unreleased",
     });
-
-    console.log(
-      Object.keys(this.config.sections)
-        .map(key => this.config.sections[key])
-        .filter(onlyUnique)
-    );
   }
 
   public async createMarkdown(options: Options = {}) {
@@ -67,7 +61,6 @@ export default class Changelog {
     // Step 6: Fill in sections (local)
     await this.fillInSections(commitInfos);
 
-    console.log(commitInfos.forEach(info => console.log(info.categories, info.section)));
     return commitInfos;
   }
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -25,9 +25,18 @@ export default class Changelog {
     this.github = new GithubAPI(this.config);
     this.renderer = new MarkdownRenderer({
       categories: Object.keys(this.config.labels).map(key => this.config.labels[key]),
+      sections: Object.keys(this.config.sections)
+        .map(key => this.config.sections[key])
+        .filter(onlyUnique),
       baseIssueUrl: this.github.getBaseIssueUrl(this.config.repo),
       unreleasedName: this.config.nextVersion || "Unreleased",
     });
+
+    console.log(
+      Object.keys(this.config.sections)
+        .map(key => this.config.sections[key])
+        .filter(onlyUnique)
+    );
   }
 
   public async createMarkdown(options: Options = {}) {
@@ -240,7 +249,7 @@ export default class Changelog {
       const labels = commit.githubIssue.labels.map(label => label.name.toLowerCase());
 
       const filteredSections = labels.filter(label => Object.keys(this.config.sections).includes(label));
-      commit.section = filteredSections.length == 0 ? this.config.sections.default : filteredSections[0];
+      commit.section = filteredSections.length == 0 ? "default" : filteredSections[0];
     }
   }
 

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -25,9 +25,7 @@ export default class Changelog {
     this.github = new GithubAPI(this.config);
     this.renderer = new MarkdownRenderer({
       categories: Object.keys(this.config.labels).map(key => this.config.labels[key]),
-      sections: Object.keys(this.config.sections)
-        .map(key => this.config.sections[key])
-        .filter(onlyUnique),
+      sections: this.config.sections,
       baseIssueUrl: this.github.getBaseIssueUrl(this.config.repo),
       unreleasedName: this.config.nextVersion || "Unreleased",
     });

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -27,7 +27,9 @@ export default class Changelog {
       categories: Object.keys(this.config.labels).map(key => this.config.labels[key]),
       sections: this.config.sections,
       baseIssueUrl: this.github.getBaseIssueUrl(this.config.repo),
-      unreleasedName: this.config.nextVersion || "Unreleased",
+      unreleasedName: this.config.nextVersion,
+      title: this.config.title,
+      description: this.config.description,
     });
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,7 @@ export async function run() {
       nextVersionFromMetadata: argv["next-version-from-metadata"],
     });
 
-    if (argv["next-version"]) {
+    if (!config.nextVersion && argv["next-version"]) {
       config.nextVersion = argv["next-version"];
     }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,8 +12,10 @@ export interface Configuration {
   sections: { [key: string]: string };
   ignoreCommitters: string[];
   cacheDir?: string;
-  nextVersion: string | undefined;
+  nextVersion: string;
   nextVersionFromMetadata?: boolean;
+  title: string;
+  description: string;
 }
 
 export interface ConfigLoaderOptions {
@@ -32,7 +34,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   let config = fromPackageConfig(rootPath) || fromLernaConfig(rootPath) || {};
 
   // Step 2: fill partial config with defaults
-  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, sections } = config;
+  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, sections, title, description } = config;
 
   if (!repo) {
     repo = findRepo(rootPath);
@@ -76,6 +78,18 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     ];
   }
 
+  if (!nextVersion) {
+    nextVersion = "Unreleased";
+  }
+
+  if (!title) {
+    title = "Changelog";
+  }
+
+  if (!description) {
+    description = "All notable changes to this project will be documented in this file.";
+  }
+
   return {
     repo,
     nextVersion,
@@ -84,6 +98,8 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     sections,
     ignoreCommitters,
     cacheDir,
+    title,
+    description,
   };
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -61,8 +61,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
 
   if (!sections) {
     sections = {
-      changes: "",
-      default: "changes",
+      default: "",
     };
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -9,6 +9,7 @@ export interface Configuration {
   repo: string;
   rootPath: string;
   labels: { [key: string]: string };
+  sections: { [key: string]: string };
   ignoreCommitters: string[];
   cacheDir?: string;
   nextVersion: string | undefined;
@@ -31,7 +32,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
   let config = fromPackageConfig(rootPath) || fromLernaConfig(rootPath) || {};
 
   // Step 2: fill partial config with defaults
-  let { repo, nextVersion, labels, cacheDir, ignoreCommitters } = config;
+  let { repo, nextVersion, labels, cacheDir, ignoreCommitters, sections } = config;
 
   if (!repo) {
     repo = findRepo(rootPath);
@@ -58,6 +59,13 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     };
   }
 
+  if (!sections) {
+    sections = {
+      changes: "",
+      default: "changes",
+    };
+  }
+
   if (!ignoreCommitters) {
     ignoreCommitters = [
       "dependabot-bot",
@@ -74,6 +82,7 @@ export function fromPath(rootPath: string, options: ConfigLoaderOptions = {}): C
     nextVersion,
     rootPath,
     labels,
+    sections,
     ignoreCommitters,
     cacheDir,
   };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -9,6 +9,7 @@ export interface CommitInfo {
   githubIssue?: GitHubIssueResponse;
   categories?: string[];
   packages?: string[];
+  section: string;
 }
 
 export interface Release {

--- a/src/markdown-renderer.ts
+++ b/src/markdown-renderer.ts
@@ -20,6 +20,8 @@ interface Options {
   sections: { [key: string]: string };
   baseIssueUrl: string;
   unreleasedName: string;
+  title: string;
+  description: string;
 }
 
 export default class MarkdownRenderer {
@@ -31,9 +33,9 @@ export default class MarkdownRenderer {
 
   public renderMarkdown(releases: Release[]) {
     // Render title and description
-
+    let output = `# ${this.options.title}\n\n${this.options.description}\n\n`;
     // Render sections and categories
-    let output = releases
+    output += releases
       .map(release => this.renderReleaseBySectionAndCategory(release))
       .filter(Boolean)
       .join("\n\n\n");
@@ -49,7 +51,7 @@ export default class MarkdownRenderer {
     if (categoriesWithCommits.length === 0) return "";
 
     const releaseTitle = release.name === UNRELEASED_TAG ? this.options.unreleasedName : release.name;
-    
+
     let markdown = `## ${releaseTitle} (${release.date})`;
 
     for (const category of categoriesWithCommits) {

--- a/src/markdown-renderer.ts
+++ b/src/markdown-renderer.ts
@@ -3,14 +3,21 @@ import { CommitInfo, Release } from "./interfaces";
 
 const UNRELEASED_TAG = "___unreleased___";
 const COMMIT_FIX_REGEX = /(fix|close|resolve)(e?s|e?d)? [T#](\d+)/i;
+const MARKDOWN_IDENTATION = "&nbsp;";
 
 interface CategoryInfo {
   name: string | undefined;
   commits: CommitInfo[];
 }
 
+interface SectionInfo {
+  name: string;
+  categories: CategoryInfo[];
+}
+
 interface Options {
   categories: string[];
+  sections: { [key: string]: string };
   baseIssueUrl: string;
   unreleasedName: string;
 }
@@ -24,7 +31,7 @@ export default class MarkdownRenderer {
 
   public renderMarkdown(releases: Release[]) {
     let output = releases
-      .map(release => this.renderRelease(release))
+      .map(release => this.renderReleaseBySectionAndCategory(release))
       .filter(Boolean)
       .join("\n\n\n");
     return output ? `\n${output}` : "";
@@ -48,6 +55,33 @@ export default class MarkdownRenderer {
       if (this.hasPackages(category.commits)) {
         markdown += this.renderContributionsByPackage(category.commits);
       } else {
+        markdown += this.renderContributionList(category.commits);
+      }
+    }
+
+    if (release.contributors) {
+      markdown += `\n\n${this.renderContributorList(release.contributors)}`;
+    }
+
+    return markdown;
+  }
+
+  public renderReleaseBySectionAndCategory(release: Release) {
+    // Group commits in release by section
+    const sections = this.groupBySection(release.commits);
+
+    // Skip this iteration if there are no commits available for the release
+    if (sections.length === 0) return this.renderRelease(release);
+
+    const releaseTitle = release.name === UNRELEASED_TAG ? this.options.unreleasedName : release.name;
+
+    let markdown = `## ${releaseTitle} (${release.date})`;
+
+    for (const section of sections) {
+      markdown += `\n\n### ${section.name}`;
+
+      for (const category of section.categories) {
+        markdown += `\n\n#### ${MARKDOWN_IDENTATION} ${category.name}\n`;
         markdown += this.renderContributionList(category.commits);
       }
     }
@@ -134,6 +168,23 @@ export default class MarkdownRenderer {
   }
 
   private groupByCategory(allCommits: CommitInfo[]): CategoryInfo[] {
+    return this.options.categories.map(name => {
+      // Keep only the commits that have a matching label with the one
+      // provided in the lerna.json config.
+      let commits = allCommits.filter(commit => commit.categories && commit.categories.indexOf(name) !== -1);
+
+      return { name, commits };
+    });
+  }
+
+  private groupBySection(allCommits: CommitInfo[]): SectionInfo[] {
+    return Object.keys(this.options.sections).map(key => {
+      let commits = allCommits.filter(commit => commit.section && commit.section === key);
+      return { name: this.options.sections[key], categories: this.groupByCategory(commits) };
+    });
+  }
+
+  private groupByCategoryAndSection(allCommits: CommitInfo[]): CategoryInfo[] {
     return this.options.categories.map(name => {
       // Keep only the commits that have a matching label with the one
       // provided in the lerna.json config.


### PR DESCRIPTION
This PR adds a sections notion to lerna-changelog. Sections can now be added alongside labels in a project's package.json and they will be picked up and rendered. This PR also fixes a bug with specifying a title for the unreleased version. The expected output for each version ,when sections are specified is the following:

# version_name

## section_name

### category ( feat, bug,...)

- [#link_to_pr]() pr_title (@committer)
- ...

Commits before a release will be grouped inside an "unreleased" version following the same template.

----
Closes enlyze/dashboard#1174